### PR TITLE
Improved domain extension for single point charts

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -94,14 +94,18 @@ nv.models.scatter = function() {
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
       if (x.domain()[0] === x.domain()[1] || y.domain()[0] === y.domain()[1]) singlePoint = true;
       if (x.domain()[0] === x.domain()[1])
-        x.domain()[0] ?
-            x.domain([x.domain()[0] - x.domain()[0] * 0.01, x.domain()[1] + x.domain()[1] * 0.01])
-          : x.domain([-1,1]);
+        if x.domain()[0]
+          delta = x.domain()[0] > 0 ? 0.01 : -0.01
+          x.domain([x.domain()[0] - x.domain()[0] * delta, x.domain()[1] + x.domain()[1] * delta])
+        else
+          x.domain([-1,1]);
 
       if (y.domain()[0] === y.domain()[1])
-        y.domain()[0] ?
-            y.domain([y.domain()[0] + y.domain()[0] * 0.01, y.domain()[1] - y.domain()[1] * 0.01])
-          : y.domain([-1,1]);
+        if y.domain()[0]
+          delta = y.domain()[0] > 0 ? 0.01 : -0.01
+          y.domain([y.domain()[0] - y.domain()[0] * delta, y.domain()[1] + y.domain()[1] * delta])
+        else
+          y.domain([-1,1]);
 
 
       x0 = x0 || x;


### PR DESCRIPTION
This PR addresses an issue when the line chart has only one datapoint with y > 0. In that case y axis was shown reversed (i.e. from 0.25 to 0.24)
