### PR TITLE
range may have only one element

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -127,7 +127,18 @@ nv.models.axis = function() {
               .attr('text-anchor', rotateLabels%360 > 0 ? 'start' : 'end');
           }
           axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-          var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
+
+          var w;
+          switch(scale.range().length) {
+          case 1:
+              w = scale.range()[0];
+              break;
+          case 2:
+              w = scale.range()[1];
+              break;
+          default:
+              w = scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]);
+          }
           axisLabel
               .attr('text-anchor', 'middle')
               .attr('y', xLabelMargin)
@@ -253,7 +264,7 @@ nv.models.axis = function() {
               if (scale(d) < scale.range()[1] + 10 || scale(d) > scale.range()[0] - 10) { // 10 is assuming text height is 16... if d is 0, leave it!
                 if (d > 1e-10 || d < -1e-10) // accounts for minor floating point errors... though could be problematic if the scale is EXTREMELY SMALL
                   d3.select(this).attr('opacity', 0);
-                
+
                 d3.select(this).select('text').attr('opacity', 0); // Don't remove the ZERO line!!
               }
             });


### PR DESCRIPTION
If `scale.range()` returns an array with only one element, this would fail and set `w = NaN`. If there is only one element returned, we might just use that. If there's two it will use the larger one and if there's more, it will do its calculation.  
